### PR TITLE
fix: citi stmt date

### DIFF
--- a/statement_parser/extractors/tabula.py
+++ b/statement_parser/extractors/tabula.py
@@ -55,7 +55,7 @@ class TabulaBaseExtractor(BaseExtractor):
 class CitiCard(TabulaBaseExtractor):
     _bank_name = BankName.CITI
     _statement_type = StatementType.CARD
-    _tabula_kwargs = {'columns': [90, 490]}
+    _tabula_kwargs = {'columns': [90, 500]}
     _column_names = ['DATE', 'DESCRIPTION', 'AMOUNT (SGD)']
     _transformers = [
         ExtractNewColumn(


### PR DESCRIPTION
Issues with parsing Citibank statement date for the month of March.

The root cause was that when tabula is splitting the columns, it broke up the statement date to be as such `Statement Date Mar 19,`, `2025`. When _get_lines() join them back together, the resulting line would be `Statement Date Mar 19,2025`. Hence the regex is unable to parse the statement. 

Solution is to split the column using a different range. Have changed it from 490 to 500.